### PR TITLE
Add support for fully qualified names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val root = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-ubiquitous-scaladoc",
-    version := "1.0.0-SNAPSHOT",
+    version := "1.0.1-SNAPSHOT",
     sbtPlugin := true,
     scriptedBufferLog := false,
     semanticdbEnabled := true,

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val root = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-ubiquitous-scaladoc",
-    version := "1.0.0",
+    version := "1.0.0-SNAPSHOT",
     sbtPlugin := true,
     scriptedBufferLog := false,
     semanticdbEnabled := true,

--- a/src/main/scala/dev/atedeg/Configuration.scala
+++ b/src/main/scala/dev/atedeg/Configuration.scala
@@ -34,6 +34,7 @@ final case class Entity(entityType: EntityType, link: String, name: String, pack
   def toBaseEntity: BaseEntity = BaseEntity(entityType, name)
   def sanitizedLink: String = link.split('#').head
   def entityId: Option[String] = link.split('#').lift(1)
+  def fullyQualifiedName: String = packageName.replace("/", ".").replace("$$", ".")
 }
 
 final case class BaseEntity(entityType: EntityType, name: String) {

--- a/src/main/scala/dev/atedeg/Configuration.scala
+++ b/src/main/scala/dev/atedeg/Configuration.scala
@@ -34,7 +34,7 @@ final case class Entity(entityType: EntityType, link: String, name: String, pack
   def toBaseEntity: BaseEntity = BaseEntity(entityType, name)
   def sanitizedLink: String = link.split('#').head
   def entityId: Option[String] = link.split('#').lift(1)
-  def fullyQualifiedName: String = packageName.replace("/", ".").replace("$$", ".")
+  def fullyQualifiedName: String = s"${packageName.replace("/", ".")}.${name}"
 }
 
 final case class BaseEntity(entityType: EntityType, name: String) {

--- a/src/main/scala/dev/atedeg/ConfigurationUtils.scala
+++ b/src/main/scala/dev/atedeg/ConfigurationUtils.scala
@@ -60,6 +60,5 @@ object ConfigurationValidation {
       }
     }
     config.rows.traverseError(getEntity)
-    AmbiguousEntityName("asd", allEntities.toList).asLeft[List[(Option[String], Entity)]]
   }
 }

--- a/src/main/scala/dev/atedeg/Errors.scala
+++ b/src/main/scala/dev/atedeg/Errors.scala
@@ -55,3 +55,7 @@ final case class CirceDecodingFailure(error: DecodingFailure) extends Error {
 final case class CirceParsingFailure(error: ParsingFailure) extends Error {
   override def toString: String = error.toString
 }
+
+final case class AmbiguousEntityName(name: String, allMatching: List[Entity]) extends Error {
+  override def toString: String = s"Use a fully qualified path, $name matches with more than one entity: $allMatching"
+}

--- a/src/sbt-test/sbt-us/ambiguous-names/.ubidoc.yaml
+++ b/src/sbt-test/sbt-us/ambiguous-names/.ubidoc.yaml
@@ -1,0 +1,6 @@
+tables:
+  - name: "table1"
+    rows:
+      - class: "Example"
+
+ignored: []

--- a/src/sbt-test/sbt-us/ambiguous-names/build.sbt
+++ b/src/sbt-test/sbt-us/ambiguous-names/build.sbt
@@ -1,0 +1,9 @@
+ThisBuild / ubidoc / targetDirectory := baseDirectory.value / "customTarget"
+ThisBuild / ubidoc / lookupDirectory := target.value / "site"
+
+scalaVersion := "3.2.0-RC2"
+
+lazy val root = (project in file("."))
+  .settings(
+    Compile / doc / target := baseDirectory.value / "target/site",
+  )

--- a/src/sbt-test/sbt-us/ambiguous-names/project/plugins.sbt
+++ b/src/sbt-test/sbt-us/ambiguous-names/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("dev.atedeg" % "sbt-ubiquitous-scaladoc" % "latest.integration")

--- a/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example1/Example1.scala
+++ b/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example1/Example1.scala
@@ -1,0 +1,6 @@
+package dev.atedeg.example1
+
+/**
+ * Example1 doc.
+ */
+case class Example()

--- a/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example2/Example2.scala
+++ b/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example2/Example2.scala
@@ -1,0 +1,6 @@
+package dev.atedeg.example2
+
+/**
+ * Example2 doc.
+ */
+case class Example()

--- a/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example2/Example2.scala
+++ b/src/sbt-test/sbt-us/ambiguous-names/src/main/scala/dev/atedeg/example2/Example2.scala
@@ -3,4 +3,6 @@ package dev.atedeg.example2
 /**
  * Example2 doc.
  */
-case class Example()
+enum Example:
+  case Case1()
+  case Case2()

--- a/src/sbt-test/sbt-us/ambiguous-names/test
+++ b/src/sbt-test/sbt-us/ambiguous-names/test
@@ -1,4 +1,5 @@
 # should fail since there are ambiguous names that could refer to two things
+
 > doc
 $ mkdir customTarget
 -> ubidoc

--- a/src/sbt-test/sbt-us/ambiguous-names/test
+++ b/src/sbt-test/sbt-us/ambiguous-names/test
@@ -1,0 +1,4 @@
+# should fail since there are ambiguous names that could refer to two things
+> doc
+$ mkdir customTarget
+-> ubidoc

--- a/src/sbt-test/sbt-us/qualified-names/.ubidoc.yaml
+++ b/src/sbt-test/sbt-us/qualified-names/.ubidoc.yaml
@@ -1,0 +1,7 @@
+tables:
+  - name: "table1"
+    rows:
+      - class: "dev.atedeg.example1.Example"
+      - case: "Example.Case1"
+
+ignored: []

--- a/src/sbt-test/sbt-us/qualified-names/build.sbt
+++ b/src/sbt-test/sbt-us/qualified-names/build.sbt
@@ -1,0 +1,21 @@
+import scala.io.Source
+
+ThisBuild / ubidoc / targetDirectory := baseDirectory.value / "customTarget"
+ThisBuild / ubidoc / lookupDirectory := target.value / "site"
+
+scalaVersion := "3.2.0-RC2"
+
+lazy val root = (project in file("."))
+  .settings(
+    Compile / doc / target := baseDirectory.value / "target/site",
+    TaskKey[Unit]("checkContent") := {
+      val file = Source.fromFile("customTarget/table1.md")
+      file.getLines.toList match {
+        case List(_header, _line, line1, line2)
+            if line1.contains("Example1 doc.")
+              && line2.contains("Case1 doc.") =>
+          ()
+        case _ => sys.error("Table generation error")
+      }
+    },
+  )

--- a/src/sbt-test/sbt-us/qualified-names/project/plugins.sbt
+++ b/src/sbt-test/sbt-us/qualified-names/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("dev.atedeg" % "sbt-ubiquitous-scaladoc" % "latest.integration")

--- a/src/sbt-test/sbt-us/qualified-names/src/main/scala/dev/atedeg/example1/Example1.scala
+++ b/src/sbt-test/sbt-us/qualified-names/src/main/scala/dev/atedeg/example1/Example1.scala
@@ -1,0 +1,6 @@
+package dev.atedeg.example1
+
+/**
+ * Example1 doc.
+ */
+case class Example()

--- a/src/sbt-test/sbt-us/qualified-names/src/main/scala/dev/atedeg/example2/Example2.scala
+++ b/src/sbt-test/sbt-us/qualified-names/src/main/scala/dev/atedeg/example2/Example2.scala
@@ -1,0 +1,11 @@
+package dev.atedeg.example2
+
+/**
+ * Example2 doc.
+ */
+enum Example:
+  /**
+    * Case1 doc.
+    */
+  case Case1()
+  case Case2()

--- a/src/sbt-test/sbt-us/qualified-names/test
+++ b/src/sbt-test/sbt-us/qualified-names/test
@@ -1,0 +1,7 @@
+# should correctly interpret fully qualified names
+
+> doc
+$ mkdir customTarget
+> ubidoc
+$ exists customTarget/table1.md
+> checkContent


### PR DESCRIPTION
This PR adds support for fully qualified names: one can specify the name of the entity whose doc needs to be readed; if it can be confused with other entities (for example if they have the same name in different packages) one has to specify a non ambiguous path to reach the wanted entity.